### PR TITLE
fix/restore tenant prefix

### DIFF
--- a/target_s3/formats/format_base.py
+++ b/target_s3/formats/format_base.py
@@ -112,13 +112,21 @@ class FormatBase(metaclass=ABCMeta):
             if self.stream_name_path_override is None
             else self.stream_name_path_override
         )
+        
         # Insert partition_by values after stream_name if present
         partition_path = ""
         if self.partition_by:
             # Process partition_by values and handle dynamic dt if enabled
             processed_partitions = self._process_partition_values(batch_start)
             partition_path = "/".join(processed_partitions) + "/"
-        folder_path = f"{self.bucket}/{self.prefix}/{stream_name}/" + partition_path
+        
+        # Add tenant prefix if provided
+        tenant_prefix = ""
+        tenant = self.config.get("tenant")
+        if tenant:
+            tenant_prefix = f"{tenant}_"
+        folder_path = f"{self.bucket}/{self.prefix}/{tenant_prefix}{stream_name}/" + partition_path
+        
         file_name = ""
         if self.config["append_date_to_prefix"]:
             grain = DATE_GRAIN[self.config["append_date_to_prefix_grain"].lower()]

--- a/target_s3/formats/format_json.py
+++ b/target_s3/formats/format_json.py
@@ -1,12 +1,13 @@
 from datetime import datetime
+import math
+import json
 
 from bson import ObjectId
-from simplejson import JSONEncoder, dumps
 
 from target_s3.formats.format_base import FormatBase
 
 
-class JsonSerialize(JSONEncoder):
+class JsonSerialize(json.JSONEncoder):
     def default(self, obj: any) -> any:
         if isinstance(obj, ObjectId):
             return str(obj)
@@ -27,7 +28,7 @@ class FormatJson(FormatBase):
         return super()._prepare_records()
 
     def _write(self) -> None:
-        return super()._write(dumps(self.records, cls=JsonSerialize, use_decimal=True, ignore_nan=True))
+        return super()._write(json.dumps(self.records, cls=JsonSerialize))
 
     def run(self) -> None:
         # use default behavior, no additional run steps needed

--- a/target_s3/formats/format_jsonl.py
+++ b/target_s3/formats/format_jsonl.py
@@ -1,12 +1,13 @@
 from datetime import datetime
+import math
+import json
 
 from bson import ObjectId
-from simplejson import JSONEncoder, dumps
 
 from target_s3.formats.format_base import FormatBase
 
 
-class JsonSerialize(JSONEncoder):
+class JsonSerialize(json.JSONEncoder):
     def default(self, obj: any) -> any:
         if isinstance(obj, ObjectId):
             return str(obj)
@@ -26,7 +27,7 @@ class FormatJsonl(FormatBase):
         return super()._prepare_records()
 
     def _write(self) -> None:
-        return super()._write('\n'.join(dumps(r, cls=JsonSerialize, ignore_nan=True) for r in self.records))
+        return super()._write('\n'.join(json.dumps(r, cls=JsonSerialize) for r in self.records))
 
     def run(self) -> None:
         # use default behavior, no additional run steps needed

--- a/target_s3/target.py
+++ b/target_s3/target.py
@@ -197,6 +197,12 @@ class Targets3(Target):
             description="List of key-value strings (e.g., 'tenant=${TENANT}') to prepend as partitions in the S3 key path after the stream name.",
         ),
         th.Property(
+            "tenant",
+            th.StringType,
+            required=False,
+            description="Optional tenant string to prefix S3 folder names.",
+        ),
+        th.Property(
             "dynamic_dt",
             th.BooleanType,
             description="Enable dynamic dt generation for each batch. When enabled, any 'dt=' entries in partition_by will use the current batch timestamp instead of static environment variables.",


### PR DESCRIPTION
Restore 'tenant' property to add tenant prefix to stream name while storing to s3

tested locally