### PR TITLE
Revert "Add setuptools dependency to pyproject.toml"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ license = "Apache 2.0"
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
 requests = "==2.32.3"
-setuptools = ">=65.0.0"
 singer-sdk = "==0.33.1"
 smart-open = {extras = ["s3"], version = "==6.4.0"}
 pyarrow = "==10.0.1"


### PR DESCRIPTION
Reverts HGData/mk-target-s3#8
Since the setuptools is now installed as part of the Dockerfile in `mk-data-ingestion-core` we need to revert it back.
https://github.com/HGData/mk-data-ingestion-core/pull/217