### PR TITLE
fix: never emit empty Singer state (RGI-1651)

### DIFF
--- a/target_s3/target.py
+++ b/target_s3/target.py
@@ -265,9 +265,12 @@ class Targets3(Target):
         STATE message (e.g. Argo credential fetch fails at login) makes this
         target emit `{}` at end-of-pipe — which Meltano then persists over the
         tenant's real bookmarks, downgrading every subsequent run to a full
-        pull. Newer SDKs (>=0.47.0) skip emission when no state was received;
-        this backports that guard. An empty Singer state carries no bookmarks,
-        so suppressing it is always safe.
+        pull. Upstream fixed this in 0.46.1 with a None sentinel (meltano/sdk
+        #3034), then deliberately broadened it in 0.47.0 to also suppress a
+        received-but-empty state (meltano/sdk#3040: "previously valid state
+        being overwritten, potentially causing state loss"); the truthiness
+        check here backports the 0.47.0+ behavior. An empty Singer state
+        carries no bookmarks, so suppressing it is always safe.
         """
         if not state:
             LOGGER.info(

--- a/target_s3/target.py
+++ b/target_s3/target.py
@@ -257,6 +257,25 @@ class Targets3(Target):
                 "target-s3: failed to emit extraction manifest: %s", exc, exc_info=True
             )
 
+    def _write_state_message(self, state: dict) -> None:
+        """Override the SDK hook to never emit an empty state (RGI-1651).
+
+        singer-sdk 0.33.1 initialises `_latest_state` to `{}` and emits it
+        unconditionally on every drain, so a tap that dies before sending any
+        STATE message (e.g. Argo credential fetch fails at login) makes this
+        target emit `{}` at end-of-pipe — which Meltano then persists over the
+        tenant's real bookmarks, downgrading every subsequent run to a full
+        pull. Newer SDKs (>=0.47.0) skip emission when no state was received;
+        this backports that guard. An empty Singer state carries no bookmarks,
+        so suppressing it is always safe.
+        """
+        if not state:
+            LOGGER.info(
+                "target-s3: no state received from tap; skipping state emission"
+            )
+            return
+        super()._write_state_message(state)
+
     def _emit_extraction_manifest(self) -> None:
         manifest_uri = os.environ.get(EXTRACTION_MANIFEST_S3_URI_ENV)
         if not manifest_uri:

--- a/target_s3/tests/test_state_emission.py
+++ b/target_s3/tests/test_state_emission.py
@@ -1,0 +1,75 @@
+"""Tests for state-message emission guard in Targets3 (RGI-1651).
+
+When the tap crashes before emitting any STATE message (e.g. Argo credential
+fetch fails at login), the target reaches end-of-pipe with its default empty
+state. singer-sdk 0.33.1 would emit that `{}` to stdout, and Meltano persists
+it over the tenant's real bookmarks — downgrading every later run to a full
+pull. These tests pin the guard: empty state is never emitted, real state
+passes through unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+
+from target_s3.target import (
+    EXTRACTION_MANIFEST_S3_URI_ENV,
+    Targets3,
+)
+
+
+SAMPLE_CONFIG = {
+    "format": {"format_type": "json"},
+    "cloud_provider": {
+        "cloud_provider_type": "aws",
+        "aws": {
+            "aws_access_key_id": "test",
+            "aws_secret_access_key": "test",
+            "aws_bucket": "test-bucket",
+            "aws_region": "us-east-1",
+        },
+    },
+    "prefix": "test",
+    "tenant": "3327",
+}
+
+
+def _make_target() -> Targets3:
+    return Targets3(config=SAMPLE_CONFIG)
+
+
+def test_empty_state_is_not_emitted(capsys):
+    """`{}` (the SDK default when no STATE was received) must not reach stdout."""
+    target = _make_target()
+    target._write_state_message({})
+    assert capsys.readouterr().out == ""
+
+
+def test_non_empty_state_is_emitted_unchanged(capsys):
+    """Real bookmark state passes through to stdout exactly as before."""
+    target = _make_target()
+    state = {"bookmarks": {"Lead": {"SystemModstamp": "2026-07-10T13:14:19.000000Z"}}}
+    target._write_state_message(state)
+    assert json.loads(capsys.readouterr().out) == state
+
+
+def test_endofpipe_with_no_input_emits_no_state(monkeypatch, capsys):
+    """Reproduces the RGI-1651 incident: tap dies pre-STATE, pipe closes.
+
+    End-of-pipe with zero input lines must produce no state line on stdout,
+    so Meltano has nothing to persist and the saved bookmarks survive.
+    """
+    monkeypatch.delenv(EXTRACTION_MANIFEST_S3_URI_ENV, raising=False)
+    target = _make_target()
+    target._process_endofpipe()
+    assert capsys.readouterr().out == ""
+
+
+def test_endofpipe_after_state_received_still_emits(monkeypatch, capsys):
+    """A normally-completing run still emits its final state at end-of-pipe."""
+    monkeypatch.delenv(EXTRACTION_MANIFEST_S3_URI_ENV, raising=False)
+    target = _make_target()
+    state = {"bookmarks": {"Contact": {"SystemModstamp": "2026-07-10T13:13:56.000000Z"}}}
+    target._process_state_message({"type": "STATE", "value": state})
+    target._process_endofpipe()
+    assert json.loads(capsys.readouterr().out) == state

--- a/target_s3/tests/test_state_emission.py
+++ b/target_s3/tests/test_state_emission.py
@@ -65,6 +65,22 @@ def test_endofpipe_with_no_input_emits_no_state(monkeypatch, capsys):
     assert capsys.readouterr().out == ""
 
 
+def test_received_empty_state_is_also_suppressed(monkeypatch, capsys):
+    """A tap-emitted `STATE {}` is suppressed too, matching singer-sdk >=0.47.0.
+
+    Deliberate, not an accident: upstream introduced a None-sentinel guard in
+    0.46.1 (meltano/sdk#3034) and broadened it in 0.47.0 (meltano/sdk#3040)
+    because persisting a received empty state still overwrites valid bookmarks
+    — the same wipe RGI-1651 fixes. State resets are operational
+    (`meltano state clear`), never signalled through the pipe.
+    """
+    monkeypatch.delenv(EXTRACTION_MANIFEST_S3_URI_ENV, raising=False)
+    target = _make_target()
+    target._process_state_message({"type": "STATE", "value": {}})
+    target._process_endofpipe()
+    assert capsys.readouterr().out == ""
+
+
 def test_endofpipe_after_state_received_still_emits(monkeypatch, capsys):
     """A normally-completing run still emits its final state at end-of-pipe."""
     monkeypatch.delenv(EXTRACTION_MANIFEST_S3_URI_ENV, raising=False)


### PR DESCRIPTION
## Problem

[RGI-1651](https://hgdata.atlassian.net/browse/RGI-1651): when the tap crashes **before emitting any STATE message** (e.g. the Argo credential fetch returns 504 during `sf.login()`), the target still emits `Emitting completed target state {}` at end-of-pipe. Meltano persists that empty state over the tenant's real bookmarks in the S3 state backend, downgrading every subsequent run to a full pull from `start_date` (2000-01-01) — which OOM-kills the 2GB extraction container every 15-minute run until someone manually restores the state file.

**Incident 2026-07-10:** the 13:31 UTC Argo outage wiped bookmarks for tenants 6206 and 5578 this way; both OOM-looped until their `state.json` was restored from S3 object versions.

## Root cause

Two composing behaviors:
1. This repo pins `singer-sdk==0.33.1`, where `Target._latest_state` defaults to `{}` and `drain_all()` calls `_write_state_message(state)` **unconditionally** — so a target that received zero input lines still prints `{}` to stdout. Upstream hit the same bug ([meltano/sdk#3000](https://github.com/meltano/sdk/issues/3000): "Final empty STATE from target clears Meltano state") and fixed it in **0.46.1** with an `is not None` sentinel ([meltano/sdk#3034](https://github.com/meltano/sdk/pull/3034)), then **deliberately broadened it in 0.47.0** to a truthiness check that also suppresses a received-but-empty state ([meltano/sdk#3040](https://github.com/meltano/sdk/pull/3040): "previously valid state being overwritten, potentially causing state loss"). The truthiness form is unchanged upstream through current 0.54.x.
2. Meltano's `BookmarkWriter` persists every state line from target stdout immediately, without checking the extractor's exit status.

## Fix

Override `_write_state_message` in `Targets3` to skip emission when state is falsy, backporting the upstream **0.47.0+** guard without the 0.33→0.5x SDK version jump. Real state passes through to `super()` unchanged.

Note this intentionally also suppresses a tap-emitted `STATE {}` (matching upstream ≥0.47.0, which superseded the 0.46.1 `is not None` design for exactly this reason): emitting a received empty state lets Meltano persist it over valid bookmarks — the same wipe this PR fixes. State resets are operational (`meltano state clear` / `--full-refresh`), not signalled through the pipe, and mk-tap-salesforce emits `STATE {}` at sync start on stateless runs, so passing it through would reopen the wipe vector.

## Tests

`target_s3/tests/test_state_emission.py` (5 tests, all passing against the pinned SDK):
- no STATE received → nothing emitted (direct + through the real `_process_endofpipe` lifecycle — the latter reproduces the incident and **fails on main**)
- tap-emitted `STATE {}` → suppressed (pins the deliberate ≥0.47.0 semantics above)
- non-empty state passes through unchanged (direct + through the lifecycle via `_process_state_message`)

The 27 pre-existing failures elsewhere in the suite reproduce identically on `main` (missing dev-only deps locally) and are unrelated.

## After this ships

A tap crash at login logs `target-s3: no state received from tap; skipping state emission` instead of emitting `{}`; Meltano has nothing to persist and the saved bookmarks survive. Note `salesforce-target-s3` in mk-data-ingestion-core tracks this repo's default branch, so this lands fleet-wide with the next image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RGI-1651]: https://hgdata.atlassian.net/browse/RGI-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ