### PR TITLE
(RGI-1937) provide extraction metadata and column dtypes as a standalone file for iceberg ingestion

### DIFF
--- a/target_s3/sinks.py
+++ b/target_s3/sinks.py
@@ -32,6 +32,9 @@ class s3Sink(BatchSink):
         # what type of file are we building?
         self.format_type = self.config.get("format", None).get("format_type", None)
         self.schema = schema
+        # S3 keys written this run, accumulated across batches. The target reads these at end-of-pipe
+        # to build the ingestion descriptor (which partitions of this stream landed, and where).
+        self._written_keys: set[str] = set()
         if self.format_type:
             if self.format_type not in FORMAT_TYPE:
                 raise Exception(
@@ -93,3 +96,8 @@ class s3Sink(BatchSink):
         ), f"format_type_client must be of type Base; Type: {type(self.format_type_client)}."
 
         format_type_client.run()
+
+        # Record the S3 key this batch wrote, for the end-of-run ingestion descriptor.
+        written_key = getattr(format_type_client, "fully_qualified_key", None)
+        if written_key:
+            self._written_keys.add(written_key)

--- a/target_s3/target.py
+++ b/target_s3/target.py
@@ -29,6 +29,16 @@ LOGGER = logging.getLogger("target-s3")
 # target outside the MDI pipeline.
 EXTRACTION_MANIFEST_S3_URI_ENV = "EXTRACTION_MANIFEST_S3_URI"
 
+# Env var pointing at the S3 URI where the post-run Iceberg ingestion descriptor should be written.
+# Set by the orchestrator; the iceberg ingestion DAG reads it to learn which streams landed, the
+# partitions each wrote, and the schema each carried. A separate file from the freshness manifest
+# above. Unset -> descriptor emission is skipped, keeping this usable as a generic Singer target.
+INGESTION_DESCRIPTOR_S3_URI_ENV = "INGESTION_DESCRIPTOR_S3_URI"
+
+# The single partition column the Iceberg int layer filters a load on. target-s3 writes it as the
+# last `dt=` segment of each key (dynamic_dt), and the descriptor names it as the partition key.
+_DT_PARTITION_MARKER = "/dt="
+
 
 class Targets3(Target):
     """Sample target for s3."""
@@ -256,6 +266,12 @@ class Targets3(Target):
             LOGGER.warning(
                 "target-s3: failed to emit extraction manifest: %s", exc, exc_info=True
             )
+        try:
+            self._emit_ingestion_descriptor()
+        except Exception as exc:  # noqa: BLE001 — must never raise here
+            LOGGER.warning(
+                "target-s3: failed to emit ingestion descriptor: %s", exc, exc_info=True
+            )
 
     def _emit_extraction_manifest(self) -> None:
         manifest_uri = os.environ.get(EXTRACTION_MANIFEST_S3_URI_ENV)
@@ -306,6 +322,76 @@ class Targets3(Target):
             _sanitize_log_uri(manifest_uri),
         )
 
+    def _emit_ingestion_descriptor(self) -> None:
+        """Write the Iceberg ingestion descriptor: one entry per stream with its landed partitions.
+
+        The descriptor carries only what landed — streams, their ``dt`` partitions and locations, and
+        the Singer schema each was extracted under. It does not carry service/tenant/connector: the
+        ingestion DAG supplies those. A stream that wrote no ``dt``-partitioned files this run is
+        omitted (there is nothing to stage for it).
+        """
+        descriptor_uri = os.environ.get(INGESTION_DESCRIPTOR_S3_URI_ENV)
+        if not descriptor_uri:
+            LOGGER.debug(
+                "target-s3: %s unset, skipping descriptor emission",
+                INGESTION_DESCRIPTOR_S3_URI_ENV,
+            )
+            return
+
+        extracted_at = datetime.now(tz=timezone.utc).isoformat()
+        streams = []
+        for stream_name, sink in self._sinks_active.items():
+            written_keys = getattr(sink, "_written_keys", None) or set()
+            table_root = None
+            # dt value -> location; a dict so replayed batches for one partition collapse to one arrival.
+            partitions: dict[str, str] = {}
+            for key in written_keys:
+                parsed = _parse_dt_partition(key)
+                if parsed is None:
+                    continue
+                table_root, dt_value, location = parsed
+                partitions[dt_value] = location
+
+            if not partitions or table_root is None:
+                LOGGER.warning(
+                    "target-s3: stream %s wrote no dt-partitioned files; omitting from descriptor",
+                    stream_name,
+                )
+                continue
+
+            arrivals = [
+                {
+                    "extracted_at": extracted_at,
+                    "partition": {"values": {"dt": dt_value}, "location": location},
+                    "schema": sink.schema,
+                }
+                for dt_value, location in sorted(partitions.items())
+            ]
+            streams.append(
+                {
+                    "stream": stream_name,
+                    "table_root": table_root,
+                    "partition_keys": [{"name": "dt", "type": "string"}],
+                    "arrivals": arrivals,
+                }
+            )
+
+        descriptor = {"version": 1, "streams": streams}
+
+        transport_params: dict = {}
+        s3_client = self._build_s3_client()
+        if s3_client is not None:
+            transport_params["client"] = s3_client
+
+        with smart_open(descriptor_uri, "w", transport_params=transport_params) as f:
+            f.write(json.dumps(descriptor, indent=2))
+
+        LOGGER.info(
+            "target-s3: wrote ingestion descriptor (streams=%d) to %s",
+            len(streams),
+            _sanitize_log_uri(descriptor_uri),
+        )
+
     def _build_s3_client(self):
         """Build an S3 client from the target's cloud_provider config.
 
@@ -350,6 +436,28 @@ class Targets3(Target):
         except json.decoder.JSONDecodeError as exc:
             self.logger.error("Unable to parse:\n%s", line, exc_info=exc)
             raise
+
+
+def _parse_dt_partition(key: str) -> tuple[str, str, str] | None:
+    """Split a written S3 key into its table root, dt value, and partition location.
+
+    A sink key looks like ``bucket/prefix/{tenant}_{stream}/source_system=.../tenant=.../dt=VALUE/file``.
+    The constant leading partitions fold into ``table_root``; the varying ``dt`` is the partition key
+    the descriptor names.
+
+    :param key: the fully-qualified S3 key a batch wrote (no ``s3://`` scheme)
+    :return: ``(table_root, dt_value, location)`` as ``s3://`` URIs, or None if the key has no ``dt=``
+
+    """
+    idx = key.find(_DT_PARTITION_MARKER)
+    if idx == -1:
+        return None
+    table_root = f"s3://{key[:idx]}/"
+    dt_value = key[idx + len(_DT_PARTITION_MARKER):].split("/", 1)[0]
+    if not dt_value:
+        return None
+    location = f"{table_root}dt={dt_value}/"
+    return table_root, dt_value, location
 
 
 def _sanitize_log_uri(uri: str) -> str:

--- a/target_s3/tests/test_ingestion_descriptor.py
+++ b/target_s3/tests/test_ingestion_descriptor.py
@@ -1,0 +1,142 @@
+"""Tests for Iceberg ingestion descriptor emission in Targets3.
+
+target-s3 writes a JSON descriptor at end-of-run to the S3 URI in INGESTION_DESCRIPTOR_S3_URI when
+it's set; the iceberg ingestion DAG reads it to learn which streams landed, their dt partitions and
+locations, and the schema each carried. It carries no service/tenant/connector — the DAG supplies
+those. Tests cover the shape, the key parsing, the env-var opt-in, and the non-throwing invariant.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from target_s3.target import (
+    INGESTION_DESCRIPTOR_S3_URI_ENV,
+    Targets3,
+    _parse_dt_partition,
+)
+
+SAMPLE_CONFIG = {
+    "format": {"format_type": "jsonl"},
+    "cloud_provider": {
+        "cloud_provider_type": "aws",
+        "aws": {
+            "aws_access_key_id": "test",
+            "aws_secret_access_key": "test",
+            "aws_bucket": "test-bucket",
+            "aws_region": "us-east-1",
+        },
+    },
+    "prefix": "data/tenants/objects",
+    "tenant": "3327",
+}
+
+_ROOT = "test-bucket/data/tenants/objects/3327_Account/source_system=salesforce/tenant=3327"
+_SCHEMA = {"type": "object", "properties": {"id": {"type": ["null", "string"]}}}
+
+
+def _make_target() -> Targets3:
+    return Targets3(config=SAMPLE_CONFIG)
+
+
+def _fake_sink(schema: dict, keys: list[str]) -> MagicMock:
+    sink = MagicMock()
+    sink.schema = schema
+    sink._written_keys = set(keys)
+    return sink
+
+
+class TestParseDtPartition:
+    def test_splits_root_dt_and_location(self) -> None:
+        """A key with a dt= segment yields table_root, dt value, and the partition location."""
+        tr, dt, loc = _parse_dt_partition(f"{_ROOT}/dt=2026-08-26-14-15/f.jsonl.gz")
+        assert tr == f"s3://{_ROOT}/"
+        assert dt == "2026-08-26-14-15"
+        assert loc == f"s3://{_ROOT}/dt=2026-08-26-14-15/"
+
+    def test_key_without_dt_returns_none(self) -> None:
+        """A key with no dt= partition cannot be described and is skipped."""
+        assert _parse_dt_partition(f"{_ROOT}/f.jsonl.gz") is None
+
+
+def test_emit_descriptor_skipped_when_env_unset(monkeypatch):
+    """Without INGESTION_DESCRIPTOR_S3_URI, descriptor emission is a silent no-op."""
+    monkeypatch.delenv(INGESTION_DESCRIPTOR_S3_URI_ENV, raising=False)
+    target = _make_target()
+    target._sinks_active = {"Account": _fake_sink(_SCHEMA, [f"{_ROOT}/dt=2026-08-26-14-15/f.jsonl.gz"])}
+
+    with patch("target_s3.target.smart_open") as mock_open:
+        target._emit_ingestion_descriptor()
+        mock_open.assert_not_called()
+
+
+def test_emit_descriptor_writes_streams_only_shape(monkeypatch, tmp_path):
+    """The descriptor lists streams with their schema and dt partitions, and no identity fields."""
+    path = tmp_path / "descriptor.json"
+    monkeypatch.setenv(INGESTION_DESCRIPTOR_S3_URI_ENV, str(path))
+    target = _make_target()
+    target._sinks_active = {"Account": _fake_sink(_SCHEMA, [f"{_ROOT}/dt=2026-08-26-14-15/f.jsonl.gz"])}
+
+    target._emit_ingestion_descriptor()
+
+    d = json.loads(path.read_text())
+    assert d["version"] == 1
+    assert "service" not in d and "tenant" not in d and "connector" not in d
+    assert len(d["streams"]) == 1
+    stream = d["streams"][0]
+    assert stream["stream"] == "Account"
+    assert stream["table_root"] == f"s3://{_ROOT}/"
+    assert stream["partition_keys"] == [{"name": "dt", "type": "string"}]
+    assert len(stream["arrivals"]) == 1
+    arrival = stream["arrivals"][0]
+    assert arrival["partition"] == {
+        "values": {"dt": "2026-08-26-14-15"},
+        "location": f"s3://{_ROOT}/dt=2026-08-26-14-15/",
+    }
+    assert arrival["schema"] == _SCHEMA
+    assert "extracted_at" in arrival
+
+
+def test_multiple_dt_partitions_become_sorted_arrivals(monkeypatch, tmp_path):
+    """Several dt partitions for one stream become one arrival each, oldest first."""
+    path = tmp_path / "descriptor.json"
+    monkeypatch.setenv(INGESTION_DESCRIPTOR_S3_URI_ENV, str(path))
+    target = _make_target()
+    target._sinks_active = {
+        "Account": _fake_sink(
+            _SCHEMA,
+            [
+                f"{_ROOT}/dt=2026-08-26-14-15/f.jsonl.gz",
+                f"{_ROOT}/dt=2026-08-26-12-00/f.jsonl.gz",
+                f"{_ROOT}/dt=2026-08-26-12-00/second-batch.jsonl.gz",  # same dt -> one arrival
+            ],
+        )
+    }
+
+    target._emit_ingestion_descriptor()
+
+    arrivals = json.loads(path.read_text())["streams"][0]["arrivals"]
+    assert [a["partition"]["values"]["dt"] for a in arrivals] == ["2026-08-26-12-00", "2026-08-26-14-15"]
+
+
+def test_stream_without_dt_partition_is_omitted(monkeypatch, tmp_path):
+    """A stream whose keys carry no dt= has nothing to stage and is left out of the descriptor."""
+    path = tmp_path / "descriptor.json"
+    monkeypatch.setenv(INGESTION_DESCRIPTOR_S3_URI_ENV, str(path))
+    target = _make_target()
+    target._sinks_active = {"Account": _fake_sink(_SCHEMA, [f"{_ROOT}/f.jsonl.gz"])}
+
+    target._emit_ingestion_descriptor()
+    assert json.loads(path.read_text())["streams"] == []
+
+
+def test_process_endofpipe_swallows_descriptor_errors(monkeypatch):
+    """Descriptor emission errors must NEVER propagate out of _process_endofpipe."""
+    monkeypatch.setenv(INGESTION_DESCRIPTOR_S3_URI_ENV, "s3://broken/uri")
+    target = _make_target()
+
+    with patch("target_s3.target.Target._process_endofpipe"), patch.object(
+        target, "_emit_extraction_manifest"
+    ), patch.object(target, "_emit_ingestion_descriptor", side_effect=RuntimeError("simulated S3 outage")):
+        target._process_endofpipe()  # must not raise


### PR DESCRIPTION
https://hgdata.atlassian.net/browse/RGI-1937

Iceberg ingestion jobs need a manifest descriptor of metadata and column dtypes. 
As all jobs go through the target-s3 worker we can use this, in the same way the `EXTRACTION_MANIFEST` file is built for pull validation etc, to generate a static file which can be read outside of the ECS container. 

This is intentionally kept separate from the EXTRACTION_MANIFEST as their uses are different and greater flexibility may be needed for the iceberg ingestion in order to align this manifest with other non meltano replication services eg pull, pull custom. 

Destination path and consumption is handled in https://github.com/HGData/mk-airflow/pull/1007